### PR TITLE
Fix memoSwap logic in MemoResult

### DIFF
--- a/src/components/MemoResult/MemoResult.tsx
+++ b/src/components/MemoResult/MemoResult.tsx
@@ -11,11 +11,11 @@ import { useContext, useEffect, useMemo, useState } from "react";
 
 import { makeCornerMemo } from "@/utils/makeMemo/makeCornerMemo";
 import { makeEdgeMemo } from "@/utils/makeMemo/makeEdgeMemo";
+import { Cube } from "react-rubiks-cube-utils";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "../ui/sheet";
 import MemoResultCorner from "./MemoResultCorner";
 import MemoResultEdge from "./MemoResultEdge";
 import QuickModify from "./QuickModify";
-import { Cube } from "react-rubiks-cube-utils";
 
 export default function MemoResult({ cube }: { cube: Cube }) {
   const context = useContext(SettingsContext);
@@ -52,7 +52,9 @@ export default function MemoResult({ cube }: { cube: Cube }) {
         ? settings.memoSwap
         : settings.edgeBuffer;
     const swap2 =
-      cornerParity && settings.memoSwap2 !== "buffer"
+      cornerParity &&
+      settings.memoSwap !== "none" &&
+      settings.memoSwap2 !== "buffer"
         ? settings.memoSwap2
         : settings.edgeBuffer;
 


### PR DESCRIPTION
This pull request makes a minor update to the `MemoResult` component to refine how memo swaps are determined when there is corner parity. The main change ensures that `settings.memoSwap2` is only used if `settings.memoSwap` is not set to "none", which fixes #21.

Logic improvement for memo swaps:

* Updated the condition for assigning `swap2` in `MemoResult` to check that `settings.memoSwap` is not "none" before using `settings.memoSwap2` when corner parity is present.

No other significant changes were made.